### PR TITLE
[5.15] serial: 8250: fix duplicate setup_irq() call in serial8250_do_startup()

### DIFF
--- a/drivers/tty/serial/8250/8250_port.c
+++ b/drivers/tty/serial/8250/8250_port.c
@@ -2294,10 +2294,6 @@ int serial8250_do_startup(struct uart_port *port)
 		}
 	}
 
-	retval = up->ops->setup_irq(up);
-	if (retval)
-		return retval;
-
 	up->ops->setup_timer(up);
 
 	/*


### PR DESCRIPTION
The merge of v5.15.85 into linux-intel-lts/5.15/linux incorrectly applied the changes from commit a91a3c2d8db8
("serial: 8250: Toggle IER bits on only after irq has been set up"), duplicating a call to setup_irq() instead of moving it. This results in backtraces like the following for each active UART:

    list_add double add: new=ffffffffb392edb0, prev=ffffffffb392edb0, next=ffffffffb392edb0.
    WARNING: CPU: 12 PID: 227 at lib/list_debug.c:33 __list_add_valid+0xb0/0xc0
    Modules linked in:
    CPU: 12 PID: 227 Comm: systemd-getty-g Not tainted 5.15.85-intel-pk-standard #1
    Hardware name: TQ-Group TQMx110EB/Type2 - Board Product Name1, BIOS 5.43.12.49.2 09/27/2021
    RIP: 0010:__list_add_valid+0xb0/0xc0
    Code: c7 c7 50 2e 10 b3 e8 fe 5f 78 00 0f 0b 31 c0 5d c3 cc cc cc cc 48 89 f2 4c 89 c1 48 89 fe 48 c7 c7 a0 2e 10 b3 e8 df 5f 78 00 <0f> 0b 31 c0 5d c3 cc cc cc cc 66 0f 1f 44 00 00 55 48 8b 17 48 89
    RSP: 0018:ffff9ca0c0773aa8 EFLAGS: 00010086
    RAX: 0000000000000000 RBX: ffffffffb392edb0 RCX: 0000000000000000
    RDX: 0000000000000002 RSI: 00000000ffffefff RDI: 00000000ffffffff
    RBP: ffff9ca0c0773aa8 R08: 0000000000000000 R09: ffff9ca0c07738a0
    R10: 0000000000000001 R11: 0000000000000001 R12: ffffffffb392edb0
    R13: ffffffffb392eba0 R14: ffffffffb392edb0 R15: ffff96bb8290df14
    FS:  00007f9d1dba1800(0000) GS:ffff96bf1fb00000(0000) knlGS:0000000000000000
    CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
    CR2: 00007f9d1e32141c CR3: 0000000104ef0003 CR4: 0000000000770ee0
    PKRU: 55555554
    Call Trace:
     <TASK>
     univ8250_setup_irq+0xef/0x1b0
     serial8250_do_startup+0x452/0x780
     serial8250_startup+0x22/0x30
     uart_port_startup+0x153/0x2e0
     uart_port_activate+0x4a/0x80
     tty_port_open+0x87/0xd0
     ? _raw_spin_unlock+0x16/0x40
     uart_open+0x1e/0x30
     tty_open+0x172/0x6a0
     chrdev_open+0xc4/0x260
     ? cdev_device_add+0xa0/0xa0
     do_dentry_open+0x167/0x3f0
     vfs_open+0x2d/0x40
     path_openat+0xbd5/0x10b0
     ? _raw_spin_unlock+0x16/0x40
     do_filp_open+0xb2/0x160
     ? __check_object_size+0x14f/0x160
     ? _raw_spin_unlock+0x16/0x40
     ? alloc_fd+0xb9/0x170
     do_sys_openat2+0x9f/0x160
     __x64_sys_openat+0x55/0x90
     do_syscall_64+0x40/0x90
     entry_SYSCALL_64_after_hwframe+0x61/0xcb
    RIP: 0033:0x7f9d1dfd101b
    Code: 25 00 00 41 00 3d 00 00 41 00 74 33 64 8b 04 25 18 00 00 00 85 c0 75 57 44 89 e2 48 89 ee bf 9c ff ff ff b8 01 01 00 00 0f 05 <48> 3d 00 f0 ff ff 0f 87 81 00 00 00 48 83 c4 68 5d 41 5c c3 90 48
    RSP: 002b:00007ffc5501edb0 EFLAGS: 00000246 ORIG_RAX: 0000000000000101
    RAX: ffffffffffffffda RBX: 00007ffc5501eec0 RCX: 00007f9d1dfd101b
    RDX: 00000000000a0902 RSI: 00007ffc5501ee30 RDI: 00000000ffffff9c
    RBP: 00007ffc5501ee30 R08: 0000000000000000 R09: 000056043b2a72a0
    R10: 0000000000000000 R11: 0000000000000246 R12: 00000000000a0902
    R13: 000056043b2a7920 R14: 000056043a2f0c98 R15: 00007f9d1e3d6000
     </TASK>