### PR TITLE
vhm: fix 'no previous prototype' error

### DIFF
--- a/drivers/char/vhm/vhm_dev.c
+++ b/drivers/char/vhm/vhm_dev.c
@@ -212,7 +212,7 @@ static long vhm_dev_ioctl(struct file *filep,
 
 		ret = hcall_create_vm(virt_to_phys(&created_vm));
 		if ((ret < 0) ||
-			(created_vm.vmid == ACRN_INVALID_VMID)) {
+			(created_vm.vmid == (uint16_t)ACRN_INVALID_VMID)) {
 			pr_err("vhm: failed to create VM from Hypervisor !\n");
 			return -EFAULT;
 		}

--- a/drivers/vbs/vq.c
+++ b/drivers/vbs/vq.c
@@ -66,7 +66,7 @@
 #include <linux/vhm/acrn_vhm_mm.h>
 
 /* helper function for remote memory map */
-void * paddr_guest2host(struct ctx *ctx, uintptr_t gaddr, size_t len)
+static void * paddr_guest2host(struct ctx *ctx, uintptr_t gaddr, size_t len)
 {
 	return map_guest_phys(ctx->vmid, gaddr, len);
 }

--- a/drivers/vhm/vhm_ioeventfd.c
+++ b/drivers/vhm/vhm_ioeventfd.c
@@ -59,6 +59,7 @@
 #include <linux/slab.h>
 
 #include <linux/vhm/acrn_common.h>
+#include <linux/vhm/vhm_eventfd.h>
 #include <linux/vhm/acrn_vhm_ioreq.h>
 #include <linux/vhm/vhm_ioctl_defs.h>
 #include <linux/vhm/vhm_hypercall.h>

--- a/drivers/vhm/vhm_irqfd.c
+++ b/drivers/vhm/vhm_irqfd.c
@@ -59,6 +59,7 @@
 #include <linux/async.h>
 #include <linux/slab.h>
 
+#include <linux/vhm/vhm_eventfd.h>
 #include <linux/vhm/acrn_common.h>
 #include <linux/vhm/acrn_vhm_ioreq.h>
 #include <linux/vhm/vhm_vm_mngt.h>

--- a/drivers/vhm/vhm_msi.c
+++ b/drivers/vhm/vhm_msi.c
@@ -53,6 +53,7 @@
 
 #include <linux/msi.h>
 #include <linux/pci.h>
+#include <linux/vhm/vhm_msi.h>
 #include <linux/vhm/acrn_hv_defs.h>
 #include <linux/vhm/vhm_hypercall.h>
 

--- a/include/linux/vhm/vhm_eventfd.h
+++ b/include/linux/vhm/vhm_eventfd.h
@@ -3,9 +3,9 @@
 
 /* ioeventfd APIs */
 struct acrn_ioeventfd;
-int acrn_ioeventfd_init(int vmid);
-int acrn_ioeventfd(int vmid, struct acrn_ioeventfd *args);
-void acrn_ioeventfd_deinit(int vmid);
+int acrn_ioeventfd_init(uint16_t vmid);
+int acrn_ioeventfd(uint16_t vmid, struct acrn_ioeventfd *args);
+void acrn_ioeventfd_deinit(uint16_t vmid);
 
 /* irqfd APIs */
 struct acrn_irqfd;


### PR DESCRIPTION
Fix no previous prototype for function 'foo' [-Werror,-Wmissing-prototypes] for ACRN VHM.

Reported-by: kernel test robot <lkp@intel.com>