### PR TITLE
Enable ISX031 Sensing GMSL support

### DIFF
--- a/drivers/media/i2c/isx031.c
+++ b/drivers/media/i2c/isx031.c
@@ -87,6 +87,7 @@ struct isx031 {
 
 	struct isx031_platform_data *platform_data;
 	struct gpio_desc *reset_gpio;
+	struct gpio_desc *fsin_gpio;
 
 	/* Streaming on/off */
 	bool streaming;
@@ -437,6 +438,15 @@ static int isx031_start_streaming(struct isx031 *isx031)
 		return ret;
 	}
 
+	/* Drive FSIN GPIO high to enable frame sync */
+	if (isx031->fsin_gpio){
+		gpiod_set_value_cansleep(isx031->fsin_gpio, 0);
+		usleep_range(300000, 500000);
+		gpiod_set_value_cansleep(isx031->fsin_gpio, 1);
+	} else {
+		dev_warn(&client->dev, "FSIN GPIO not available during streaming start\n");
+	}
+
 	return 0;
 }
 
@@ -445,6 +455,15 @@ static void isx031_stop_streaming(struct isx031 *isx031)
 	struct i2c_client *client = isx031->client;
 	if (isx031_mode_transit(isx031, ISX031_STATE_STARTUP))
 		dev_err(&client->dev, "failed to stop streaming");
+
+	/* Drive FSIN GPIO low to disable frame sync */
+	if (isx031->fsin_gpio){
+		gpiod_set_value_cansleep(isx031->fsin_gpio, 1);
+		usleep_range(300000, 500000);
+		gpiod_set_value_cansleep(isx031->fsin_gpio, 0);
+	} else {
+		dev_warn(&client->dev, "FSIN GPIO not available during streaming stop\n");
+	}
 }
 
 static int isx031_set_stream(struct v4l2_subdev *sd, int enable)
@@ -773,6 +792,8 @@ static int isx031_probe(struct i2c_client *client)
 
 	isx031->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset",
 						     GPIOD_OUT_HIGH);
+	isx031->fsin_gpio = devm_gpiod_get_optional(&client->dev, "fsin",
+						     GPIOD_OUT_LOW);	
 	if (IS_ERR(isx031->reset_gpio))
 		return -EPROBE_DEFER;
 	else if (isx031->reset_gpio == NULL)

--- a/drivers/media/i2c/max9x/serdes.c
+++ b/drivers/media/i2c/max9x/serdes.c
@@ -1656,12 +1656,15 @@ static int max9x_registered(struct v4l2_subdev *sd)
 						.table = {
 							GPIO_LOOKUP("", 0, "reset",
 								    GPIO_ACTIVE_HIGH),
+							GPIO_LOOKUP("", 7, "fsin",
+									GPIO_ACTIVE_HIGH),
 							{}
 						},
 					};
 
 					sensor_gpios.dev_id = dev_id;
 					sensor_gpios.table[0].key = common->gpio_chip.label;
+					sensor_gpios.table[1].key = common->gpio_chip.label;
 
 					gpiod_add_lookup_table(&sensor_gpios);
 


### PR DESCRIPTION
1. Add support on ISX031 D3 MIPI Direct
- Added FSIN GPIO for frame sync support
- Modified _isx031_start_streaming_ and __isx031_stop_streaming_ functions with toggling sequence for FSIN GPIO